### PR TITLE
[#19] style: dialog transition

### DIFF
--- a/src/components/shared/Dialog/index.tsx
+++ b/src/components/shared/Dialog/index.tsx
@@ -32,9 +32,9 @@ function Dialog({ title, ContentComponent }: DialogProps) {
       openCallback(openDialog)
     }, [openCallback, openDialog])
 
-    if (!open) return <></>
+    if (!open) return <StyledDialog></StyledDialog>
     return (
-      <StyledDialog>
+      <StyledDialog className="open">
         {title && (
           <div className="header">
             <BiChevronLeft className="arrow" onClick={e => closeDialog(e)} />

--- a/src/components/shared/Dialog/style.ts
+++ b/src/components/shared/Dialog/style.ts
@@ -13,7 +13,6 @@ const Dialog = styled.div`
 
   &.open {
     left: 0px;
-    right: 0px;
   }
 
   .header {

--- a/src/components/shared/Dialog/style.ts
+++ b/src/components/shared/Dialog/style.ts
@@ -4,11 +4,17 @@ import '@src/assets/style/__pallette.css'
 const Dialog = styled.div`
   position: fixed;
   top: 0px;
-  left: 0px;
-  right: 0px;
+  left: 100vw;
+  width: 100vw;
   bottom: 0px;
   background-color: white;
   z-index: 1;
+  transition: 0.2s;
+
+  &.open {
+    left: 0px;
+    right: 0px;
+  }
 
   .header {
     padding-top: 1rem;


### PR DESCRIPTION
다이얼로그가 열릴때 오른쪽에서 왼쪽으로 나타나도록 transition을 적용했습니다.
![Apr-07-2021 16-21-48](https://user-images.githubusercontent.com/49256790/113826809-8c191800-97bd-11eb-8023-46a26563ace0.gif)
